### PR TITLE
Add GITHUB_TOKEN to releases job

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -112,6 +112,8 @@ jobs:
       - name: Create GitHub Release
         if: ${{ github.event_name != 'pull_request' }}
         uses: comnoco/create-release-action@v2.0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ matrix.changed_dir }}/v${{ steps.calculate_version.outputs.version }}
           release_name: ${{ matrix.changed_dir }} - v${{ steps.calculate_version.outputs.version }}

--- a/binary-builder-glibc/config.yml
+++ b/binary-builder-glibc/config.yml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.1.1
 description: Builder image for Rust binaries that must be built with the correct glibc version
 platforms:
   - linux/arm64

--- a/binary-builder-musl/config.yml
+++ b/binary-builder-musl/config.yml
@@ -1,4 +1,4 @@
-version: 0.1.0
+version: 0.1.1
 description: Builder image for Rust binaries that must be built & linked with musl
 platforms:
   - linux/arm64


### PR DESCRIPTION
Turns out the release action has an undocumented requirements that you have to provide the token yourself 😠 

This resolves that issue