### PR TITLE
Add a skip if matrix is empty so final part triggers

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -30,6 +30,7 @@ jobs:
           CHANGED_DIRS=$(echo "${{ steps.calculate_changed_files.outputs.all_changed_files }}" | jq -c '[.[] | select(. |  contains(".") | not)'])
           echo "changed_dirs=$CHANGED_DIRS" >> "$GITHUB_OUTPUT"
   build-and-push-images:
+    if: ${{ needs.calculate-images-to-build.outputs.changed_dirs != '' && toJson(fromJson(needs.calculate-images-to-build.outputs.changed_dirs)) != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
As per title, this should make the CI better able to deal with none Docker related changes