### PR TITLE
Use the Manifest Digest instead of Index Digest

### DIFF
--- a/binary-builder-glibc/Dockerfile
+++ b/binary-builder-glibc/Dockerfile
@@ -1,7 +1,7 @@
 # The SHA below is rockylinux:8.9.20231119, fixing to a specific SHA
 # rather than a mutable tag, stops rebuilds completely changing the
 # contents of the container without us realising.
-FROM rockylinux@sha256:9794037624aaa6212aeada1d28861ef5e0a935adaf93e4ef79837119f2a2d04c
+FROM rockylinux@sha256:2d05a9266523bbf24f33ebc3a9832e4d5fd74b973c220f2204ca802286aa275d
 
 ARG RUST_VERSION=1.80.1
 ARG NODE_VERSION=20.15.1

--- a/binary-builder-glibc/config.yml
+++ b/binary-builder-glibc/config.yml
@@ -1,4 +1,4 @@
-version: 0.1.1
+version: 0.1.2
 description: Builder image for Rust binaries that must be built with the correct glibc version
 platforms:
   - linux/arm64


### PR DESCRIPTION
As per title, the digest being used for RockyLinux was incorrect and as such Renovate was not working correctly.