### PR TITLE
Use the Docker tags properly for Renovate

### DIFF
--- a/binary-builder-glibc/Dockerfile
+++ b/binary-builder-glibc/Dockerfile
@@ -1,7 +1,7 @@
 # The SHA below is rockylinux:8.9.20231119, fixing to a specific SHA
 # rather than a mutable tag, stops rebuilds completely changing the
 # contents of the container without us realising.
-FROM rockylinux@sha256:9794037624aaa6212aeada1d28861ef5e0a935adaf93e4ef79837119f2a2d04c
+FROM rockylinux:8.9.20231119@sha256:9794037624aaa6212aeada1d28861ef5e0a935adaf93e4ef79837119f2a2d04c
 
 ARG RUST_VERSION=1.80.1
 ARG NODE_VERSION=20.15.1

--- a/binary-builder-glibc/config.yml
+++ b/binary-builder-glibc/config.yml
@@ -1,4 +1,4 @@
-version: 0.1.1
+version: 0.1.2
 description: Builder image for Rust binaries that must be built with the correct glibc version
 platforms:
   - linux/arm64

--- a/binary-builder-musl/Dockerfile
+++ b/binary-builder-musl/Dockerfile
@@ -1,7 +1,7 @@
 # The SHA below is rust:1.80.1-alpine3.19, fixing to a specific SHA
 # rather than a mutable tag, stops rebuilds completely changing the
 # contents of the container without us realising.
-FROM rust@sha256:b3ac1f65cf33390407c9b90558eb41e7a8311c47d836fca5800960f1aa2d11d5
+FROM rust:1.80.1-alpine3.19@sha256:b3ac1f65cf33390407c9b90558eb41e7a8311c47d836fca5800960f1aa2d11d5
 
 # Update packages and package manager to keep us current
 RUN apk update && apk upgrade

--- a/binary-builder-musl/config.yml
+++ b/binary-builder-musl/config.yml
@@ -1,4 +1,4 @@
-version: 0.1.1
+version: 0.1.2
 description: Builder image for Rust binaries that must be built & linked with musl
 platforms:
   - linux/arm64


### PR DESCRIPTION
In my ignorance I hadn't seen that Docker allows you to be more specific in your tagging, and this is what renovate is relying on. So fixing this will stop it raising PRs for Rust images that won't ever work.