### PR TITLE
Fix up Renovate and Dockerfiles

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,16 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    // Ensure that we don't get automated bumps to new major versions of base images, these will always be
+    // done manually
+    {
+      "matchFileNames": [
+        "Dockerfile"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    }
+  ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,8 +14,9 @@
       "enabled": false
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": [
         "(^|/)Dockerfile$",
         "(^|/)Dockerfile\\.[^/]*$"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,12 +5,24 @@
     // done manually
     {
       "matchFileNames": [
-        "Dockerfile"
+        "(^|/)Dockerfile$",
+        "(^|/)Dockerfile\\.[^/]*$"
       ],
       "matchUpdateTypes": [
         "major"
       ],
       "enabled": false
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        "(^|/)Dockerfile$",
+        "(^|/)Dockerfile\\.[^/]*$"
+      ],
+      "matchStrings": [
+        "#\\srenovate:\\sdatasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s(ENV|ARG) .*?_VERSION=(?<currentValue>.*)\\s"
+      ]
     }
   ]
 }

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -16,10 +16,10 @@ jobs:
       changed_dirs: ${{ steps.filter_config_directories.outputs.changed_dirs }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - name: "Calculate changed files directories"
         id: calculate_changed_files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c
         with:
           dir_names: true
           dir_names_exclude_current_dir: true
@@ -44,9 +44,9 @@ jobs:
         changed_dir: ${{ fromJSON(needs.calculate-images-to-build.outputs.changed_dirs ) }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
       - name: Log in to the Container Registry
-        uses: docker/login-action@3b8fed7e4b60203b2aa0ecc6c6d6d91d12c06760
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -69,10 +69,10 @@ jobs:
           VERSION=${{ github.event_name == 'pull_request' && format('{0}-PR{1}.{2}', steps.extract_from_config_yaml.outputs.desired_version, github.event.number, github.event.pull_request.head.sha) || steps.extract_from_config_yaml.outputs.desired_version}}
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8026d2bc3645ea78b0d2544766a1225eb5691f89
       - name: Get Docker Metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
         env:
           DOCKER_METADATA_PR_HEAD_SHA: true
         with:
@@ -92,7 +92,7 @@ jobs:
             org.opencontainers.image.licenses=MIT
       - name: Build and Push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
         with:
           context: ${{ github.workspace }}/${{ matrix.changed_dir }}
           file: ${{ github.workspace }}/${{ matrix.changed_dir }}/Dockerfile
@@ -102,7 +102,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ steps.extract_from_config_yaml.outputs.platforms }}
       - name: Create Git Tag
-        uses: mathieudutour/github-tag-action@v6.2
+        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: false
@@ -112,7 +112,7 @@ jobs:
           tag_prefix: ""
       - name: Create GitHub Release
         if: ${{ github.event_name != 'pull_request' }}
-        uses: comnoco/create-release-action@v2.0.5
+        uses: comnoco/create-release-action@7dea6dc82ac9d97ced7a764aa82811451bba80e0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -30,6 +30,7 @@ jobs:
           CHANGED_DIRS=$(echo "${{ steps.calculate_changed_files.outputs.all_changed_files }}" | jq -c '[.[] | select(. |  contains(".") | not)'])
           echo "changed_dirs=$CHANGED_DIRS" >> "$GITHUB_OUTPUT"
   build-and-push-images:
+    name: Build and Push Docker Image
     if: ${{ needs.calculate-images-to-build.outputs.changed_dirs != '' && toJson(fromJson(needs.calculate-images-to-build.outputs.changed_dirs)) != '[]' }}
     runs-on: ubuntu-latest
     permissions:

--- a/binary-builder-glibc/Dockerfile
+++ b/binary-builder-glibc/Dockerfile
@@ -1,9 +1,10 @@
-# The SHA below is rockylinux:8.9.20231119, fixing to a specific SHA
-# rather than a mutable tag, stops rebuilds completely changing the
-# contents of the container without us realising.
-FROM rockylinux:8.9.20231119@sha256:9794037624aaa6212aeada1d28861ef5e0a935adaf93e4ef79837119f2a2d04c
+# Fixing to a specific SHA rather than a mutable tag, stops rebuilds completely
+# changing the contents of the container without us realising.
+FROM rockylinux:8@sha256:9794037624aaa6212aeada1d28861ef5e0a935adaf93e4ef79837119f2a2d04c
 
+# renovate: datasource=github-releases depName=rust-lang/rust extractVersion=^v(?<version>.*)$
 ARG RUST_VERSION=1.80.1
+# Don't set this to bump automatically as it should move as the version does that's bundled with Alpine
 ARG NODE_VERSION=20.15.1
 
 # Add .cargo/bin to PATH

--- a/binary-builder-glibc/config.yml
+++ b/binary-builder-glibc/config.yml
@@ -1,4 +1,4 @@
-version: 0.1.2
+version: 0.1.3
 description: Builder image for Rust binaries that must be built with the correct glibc version
 platforms:
   - linux/arm64

--- a/binary-builder-musl/Dockerfile
+++ b/binary-builder-musl/Dockerfile
@@ -1,7 +1,10 @@
-# The SHA below is rust:1.80.1-alpine3.19, fixing to a specific SHA
-# rather than a mutable tag, stops rebuilds completely changing the
-# contents of the container without us realising.
-FROM rust:1.80.1-alpine3.19@sha256:b3ac1f65cf33390407c9b90558eb41e7a8311c47d836fca5800960f1aa2d11d5
+# Fixing to a specific SHA rather than a mutable tag, stops rebuilds completely
+# changing the contents of the container without us realising.
+
+# renovate: datasource=github-releases depName=rust-lang/rust extractVersion=^v(?<version>.*)$
+ARG RUST_VERSION=1.80.1
+
+FROM rust:${RUST_VERSION}-alpine3.19@sha256:b3ac1f65cf33390407c9b90558eb41e7a8311c47d836fca5800960f1aa2d11d5
 
 # Update packages and package manager to keep us current
 RUN apk update && apk upgrade

--- a/binary-builder-musl/config.yml
+++ b/binary-builder-musl/config.yml
@@ -1,4 +1,4 @@
-version: 0.1.2
+version: 0.1.3
 description: Builder image for Rust binaries that must be built & linked with musl
 platforms:
   - linux/arm64


### PR DESCRIPTION
There were some kinks in how Renovate operated on this repo, including allowing major version bumps and allowing the Rust version to go out of sync between the two images where it's important it remains consistent. This fixes that, adding new Renovate config and updating the Dockerfiles to support it.

Also adds a bit of a security fix such that in our GitHub Actions workflow we pin to specific SHAs for actions rather than mutable tags