### PR TITLE
Make sure we extend Apollo's Renovate Config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,8 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>apollographql/renovate-config-apollo-open-source:default.json5"
+  ],
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     // Ensure that we don't get automated bumps to new major versions of base images, these will always be
     // done manually


### PR DESCRIPTION
As per title, and also ensure that we don't take bleeding edge updates so as to stop very quick supply chain attacks

Validate with `renovate-config-validator` and all is good