### PR TITLE
Add new `apollo-rust-builder-musl` image

### DIFF
--- a/apollo-rust-builder-musl/Dockerfile
+++ b/apollo-rust-builder-musl/Dockerfile
@@ -1,0 +1,35 @@
+# renovate: datasource=github-releases depName=nodejs/node extractVersion=^v(?<version>.*)$
+ARG NODE_VERSION=20.15.1
+
+FROM node:${NODE_VERSION}-alpine AS node
+
+# Fixing to a specific SHA rather than a mutable tag, stops rebuilds completely
+# changing the contents of the container without us realising.
+FROM rust:1-alpine@sha256:541a1720c1cedddae9e17b4214075bf57c20bc7b176b4bba6bce3437c44d51ef
+
+ARG TARGETPLATFORM
+
+COPY --from=node /usr/lib/* /usr/lib/
+COPY --from=node /usr/local/lib/* /usr/local/lib/
+COPY --from=node /usr/local/include/* /usr/local/include/
+COPY --from=node /usr/local/bin/* /usr/local/bin/
+
+# Update packages and package manager to keep us current
+RUN apk update && apk upgrade
+
+# Add tools to enable `musl` compilation and other utilities when building in Rust
+RUN apk add musl-dev curl cmake openssl gcc perl cmake git make openssh-client ca-certificates sudo \
+    jq g++ elfutils docker
+
+# Add the specific `musl` target to make sure we don't build for `glibc` by accident
+RUN case $TARGETPLATFORM in \
+        linux/amd64) \
+            rustup target add x86_64-unknown-linux-musl \
+            ;; \
+        linux/arm64) \
+            rustup target add aarch64-unknown-linux-musl \
+            ;; \
+        *) \
+            echo "TARGETPLATFORM $TARGETPLATFORM not recognised, not installing a target" \
+            ;; \
+    esac

--- a/apollo-rust-builder-musl/README.md
+++ b/apollo-rust-builder-musl/README.md
@@ -1,0 +1,8 @@
+# Binary Builder (`musl`)
+
+The image contained herein is an image that should be used
+to _build_ Rust binaries at Apollo.
+
+It contains Alpine 3.19, and Rust at version 1.80.1 and is based on the published rust images.
+
+Using images like this ensures compliance with our new standards for Rust binary building.

--- a/apollo-rust-builder-musl/README.md
+++ b/apollo-rust-builder-musl/README.md
@@ -1,4 +1,4 @@
-# Apollo Rust Build (`musl`)
+# Apollo Rust Builder (`musl`)
 
 The image contained herein is an image that should be used
 to _build_ Rust binaries at Apollo, where `musl` rather `glibc` is needed.

--- a/apollo-rust-builder-musl/README.md
+++ b/apollo-rust-builder-musl/README.md
@@ -1,7 +1,7 @@
 # Apollo Rust Builder (`musl`)
 
 The image contained herein is an image that should be used
-to _build_ Rust binaries at Apollo, where `musl` rather `glibc` is needed.
+to _build_ Rust binaries at Apollo, where `musl` rather than `glibc` is needed.
 
 It's based on the `rust-1:alpine` image and so will move as that image moves.
 

--- a/apollo-rust-builder-musl/README.md
+++ b/apollo-rust-builder-musl/README.md
@@ -1,8 +1,10 @@
-# Binary Builder (`musl`)
+# Apollo Rust Build (`musl`)
 
 The image contained herein is an image that should be used
-to _build_ Rust binaries at Apollo.
+to _build_ Rust binaries at Apollo, where `musl` rather `glibc` is needed.
 
-It contains Alpine 3.19, and Rust at version 1.80.1 and is based on the published rust images.
+It's based on the `rust-1:alpine` image and so will move as that image moves.
 
-Using images like this ensures compliance with our new standards for Rust binary building.
+Using images like this ensures compatability with the broadest
+range of Linux distributions that are currently under an LTS policy,
+and ensures compliance with our new standards for Rust binary building.

--- a/apollo-rust-builder-musl/config.yml
+++ b/apollo-rust-builder-musl/config.yml
@@ -1,0 +1,5 @@
+version: 0.1.3
+description: Builder image for Rust binaries that must be built & linked with musl
+platforms:
+  - linux/arm64
+  - linux/amd64

--- a/apollo-rust-builder-musl/config.yml
+++ b/apollo-rust-builder-musl/config.yml
@@ -1,4 +1,4 @@
-version: 0.1.3
+version: 0.1.0
 description: Builder image for Rust binaries that must be built & linked with musl
 platforms:
   - linux/arm64

--- a/apollo-rust-builder/Dockerfile
+++ b/apollo-rust-builder/Dockerfile
@@ -8,7 +8,7 @@ ARG RUST_VERSION=1.86.0
 ARG YQ_VERSION=4.45.1
 # renovate: datasource=github-releases depName=volta-cli/volta extractVersion=^v(?<version>.*)$
 ARG VOLTA_VERSION=2.0.2
-# Don't set this to bump automatically as it should move as the version does that's bundled with Alpine
+# renovate: datasource=github-releases depName=nodejs/node extractVersion=^v(?<version>.*)$
 ARG NODE_VERSION=20.15.1
 ARG TARGETPLATFORM
 

--- a/apollo-rust-builder/config.yml
+++ b/apollo-rust-builder/config.yml
@@ -1,4 +1,4 @@
-version: 0.4.0
+version: 0.5.0
 description: Builder image for Rust binaries
 platforms:
   - linux/arm64


### PR DESCRIPTION
Now that we have our new `apollo-rust-builder` we should add a new musl variant. We also can now standardise our `node` version across both images due to an innovative new technique with multi-stage builds.