### PR TITLE
Group GitHub Actions bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,16 @@
         "major"
       ],
       "enabled": false
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "digest": {
+        "groupName": "GitHub Actions Digests",
+        "groupSlug": "gha-digests",
+        "automerge": true
+      }
     }
   ],
   // Allow ourselves to specify bits in Docker Images that should be updated by Renovate as well

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,7 +23,6 @@
       "digest": {
         "groupName": "GitHub Actions Digests",
         "groupSlug": "gha-digests",
-        "automerge": true
       }
     }
   ],


### PR DESCRIPTION
As per title, make sure we don't end up with loads of Renovate PRs for no real value