### PR TITLE
Add which to solve for fedutils-build-plugins

### DIFF
--- a/apollo-rust-builder/Dockerfile
+++ b/apollo-rust-builder/Dockerfile
@@ -23,7 +23,7 @@ RUN microdnf upgrade
 RUN microdnf install --nodocs --noplugins yum-utils && \
     yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
     microdnf install --nodocs --noplugins perl-core openssl-devel cmake git make openssh-clients ca-certificates sudo  \
-          unzip jq wget gcc gcc-c++ elfutils-devel docker-ce docker-ce-cli containerd.io python312 && \
+          unzip jq wget gcc gcc-c++ elfutils-devel docker-ce docker-ce-cli containerd.io python312 which && \
     microdnf clean all && \
     rm -rf /var/cache/yum
 

--- a/apollo-rust-builder/config.yml
+++ b/apollo-rust-builder/config.yml
@@ -1,4 +1,4 @@
-version: 0.11.1
+version: 0.11.2
 description: Builder image for Rust binaries
 platforms:
   - linux/arm64


### PR DESCRIPTION
Turns out the `which` utility is missing which is causing problems for `fedutils-build-pluigins` this PR re-adds it.